### PR TITLE
Fix SQL query for empty song list

### DIFF
--- a/docker/utils/common.py
+++ b/docker/utils/common.py
@@ -13,13 +13,19 @@ def dict_factory(cursor, row):
 
 
 def get_song_titles(songNumberList):
+    """Return a dict of songNumber to songName for the given numbers."""
+    if not songNumberList:
+        return {}
+
     conn = sqlite3.connect(os.path.join(base_dir, "songlist.sqlite"))
     cur = conn.cursor()
 
     placeholders = ",".join("?" for _ in songNumberList)
-    q = f"SELECT songNumber, songName FROM songs WHERE songNumber IN ({placeholders})"
+    query = (
+        f"SELECT songNumber, songName FROM songs WHERE songNumber IN ({placeholders})"
+    )
 
-    cur.execute(q, songNumberList)
+    cur.execute(query, songNumberList)
     rows = cur.fetchall()
     conn.close()
 


### PR DESCRIPTION
## Summary
- avoid invalid SQL when song list is empty in `get_song_titles`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68521cd363fc8329802f6af063d4cd39