### PR TITLE
Refine reservation lookup ordering and metadata

### DIFF
--- a/docker/app.py
+++ b/docker/app.py
@@ -6,18 +6,23 @@ from google.cloud import storage
 import datetime
 import firebase_admin
 import os
-import requests
 import sqlite3
 
 
 # from config import base_dir, video_files_dir, resv_api_url
-from config import base_dir, resv_api_url
+from config import base_dir
 from routes import register_blueprints
 from utils.common import dict_factory
 # VIDEO_DIR = os.path.join(video_files_dir, "video")
 # PROCESSED_DIR = os.path.join(video_files_dir, "processed")
 # os.makedirs(PROCESSED_DIR, exist_ok=True)
 
+
+if not firebase_admin._apps:
+    try:
+        firebase_admin.initialize_app(credentials.ApplicationDefault())
+    except Exception:
+        firebase_admin.initialize_app()
 
 db = firestore.client()
 
@@ -66,13 +71,73 @@ def favicon():
 
 @app.route("/next_reserved_song")
 def next_reserved_song():
+    reservations_ref = db.collection("reservations")
+
+    documents = []
     try:
-        res = requests.get(resv_api_url, timeout=3)
-        res.raise_for_status()
-        return jsonify(res.json())
-    except requests.RequestException as e:
-        # print("予約システムへの接続エラー:", e)
-        return jsonify({"has_next": False})
+        documents = list(
+            reservations_ref.order_by("order").order_by("created_at").limit(20).stream()
+        )
+    except Exception:
+        try:
+            documents = list(reservations_ref.order_by("created_at").limit(20).stream())
+        except Exception:
+            documents = []
+
+    skip_statuses = {
+        "canceled",
+        "cancelled",
+        "finished",
+        "in-progress",
+        "playing",
+        "done",
+    }
+
+    for doc in documents:
+        data = doc.to_dict() or {}
+        status = data.get("status")
+        normalized_status = ""
+        if status is not None:
+            normalized_status = str(status).replace("_", "-").replace(" ", "-").lower()
+        if normalized_status in skip_statuses:
+            continue
+
+        song = {"id": doc.id}
+
+        if "songNumber" in data:
+            song["songNumber"] = data["songNumber"]
+
+        order_value = data.get("order")
+        if order_value is not None:
+            if isinstance(order_value, (int, float)):
+                song["order"] = order_value
+            else:
+                try:
+                    song["order"] = int(order_value)
+                except (TypeError, ValueError):
+                    # Skip entries with non-numeric order values
+                    continue
+
+        for field in ("status", "source"):
+            if field in data:
+                song[field] = data[field]
+
+        created_at = data.get("created_at")
+        if created_at is not None:
+            timestamp_value = None
+            if isinstance(created_at, datetime.datetime):
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=datetime.timezone.utc)
+                timestamp_value = int(created_at.timestamp())
+            elif hasattr(created_at, "seconds") and hasattr(created_at, "nanoseconds"):
+                timestamp_value = int(created_at.seconds + created_at.nanoseconds / 1_000_000_000)
+
+            if timestamp_value is not None:
+                song["created_at"] = timestamp_value
+
+        return jsonify({"has_next": True, "song": song})
+
+    return jsonify({"has_next": False})
 
 
 @app.route("/song_info/<songNumber>", methods=["GET"])


### PR DESCRIPTION
## Summary
- query reservations ordered by numeric `order` with `created_at` as a secondary sort and fall back cleanly when the `order` index is unavailable
- broaden skipped statuses and normalise metadata handling when picking the next reservation
- normalise timestamp conversion and filter out entries with non-numeric order values to keep the queue consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd22e2a948329a750a79df3c61d2f