### PR TITLE
再生中タイトルバーに予約曲名を表示

### DIFF
--- a/docker/static/js/script.js
+++ b/docker/static/js/script.js
@@ -180,6 +180,16 @@ document.addEventListener("DOMContentLoaded", () => {
             });
     }
 
+    function fetchSongNameByNumber(songNumber) {
+        return fetch(`/song_info/${songNumber}`)
+            .then(response => response.json())
+            .then(data => data?.songName || "")
+            .catch(error => {
+                console.error("曲名取得失敗:", error);
+                return "";
+            });
+    }
+
     function sendPlaybackEvent(eventType) {
         fetch(`/control/${eventType}`, {
             method: 'POST',
@@ -508,7 +518,22 @@ document.addEventListener("DOMContentLoaded", () => {
         inputBox.style.color = "transparent";
         video.src = filename;
         video.style.display = "block";
-        updateTitleBarContent([highlightGreatLeaders(addSpacesIfShort(sessionState.songInfo.songName)), defaultTitleBarMessage]);
+        const nowPlayingTitle = highlightGreatLeaders(addSpacesIfShort(sessionState.songInfo.songName));
+        updateTitleBarContent([nowPlayingTitle, defaultTitleBarMessage]);
+
+        fetchNextReservedSong().then(next => {
+            if (!next.has_next || !next.song || !next.song.songNumber) {
+                return;
+            }
+
+            fetchSongNameByNumber(next.song.songNumber).then(nextSongName => {
+                if (!nextSongName) {
+                    return;
+                }
+                const nextSongTitle = `다음곡: ${highlightGreatLeaders(nextSongName)}`;
+                updateTitleBarContent([nowPlayingTitle, nextSongTitle, defaultTitleBarMessage]);
+            });
+        });
 
         video.play().then(() => {
             sendPlaybackEvent("playStarted"); // Discordのためだけ
@@ -607,4 +632,3 @@ document.addEventListener("DOMContentLoaded", () => {
 
     console.log("《발사준비 끝!》");
 });
-


### PR DESCRIPTION
### Motivation
- 演奏開始時に予約されている次の曲名をタイトルバーに表示して視認性を向上させるため、指定書式 `다음곡: {曲名}` で表示する機能を追加します。

### Description
- `fetchSongNameByNumber(songNumber)` を追加し、`/song_info/{songNumber}` から `songName` を取得して存在しなければ空文字を返すようにしました。
- `playVideo(filename)` を変更して再生開始時に現在再生中のタイトルを設定し、その後 `fetchNextReservedSong()` で予約があれば次曲の曲名を取得して `다음곡: {曲名}` をタイトルローテーションに挿入するようにしました。
- 既存のタイトルローテーション・フォールバックや例外処理は維持しており、曲名取得に失敗した場合は表示更新をスキップします。
- 変更は `docker/static/js/script.js` に適用しました。

### Testing
- `node --check docker/static/js/script.js` を実行して構文チェックを行い問題は検出されませんでした（成功）。
- `python3 docker/app.py` を起動しての統合確認を試みましたが、`ModuleNotFoundError: No module named 'config'` によりアプリ起動は実行できませんでした（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a4feb58883299a13878ac55dab05)