### PR TITLE
Return list of reserved songs from `/next_reserved_song` and add client-side selection/sorting

### DIFF
--- a/docker/app.py
+++ b/docker/app.py
@@ -93,6 +93,8 @@ def next_reserved_song():
         "done",
     }
 
+    reserved_songs = []
+
     for doc in documents:
         data = doc.to_dict() or {}
         status = data.get("status")
@@ -135,9 +137,9 @@ def next_reserved_song():
             if timestamp_value is not None:
                 song["created_at"] = timestamp_value
 
-        return jsonify({"has_next": True, "song": song})
+        reserved_songs.append(song)
 
-    return jsonify({"has_next": False})
+    return jsonify({"reserved_songs": reserved_songs})
 
 
 @app.route("/song_info/<songNumber>", methods=["GET"])

--- a/docker/static/js/script.js
+++ b/docker/static/js/script.js
@@ -176,8 +176,39 @@ document.addEventListener("DOMContentLoaded", () => {
             .then(response => response.json())
             .catch(error => {
                 console.error("予約システム問い合わせ失敗:", error);
-                return { has_next: false };
+                return { reserved_songs: [] };
             });
+    }
+
+    function fetchSongNameByNumber(songNumber) {
+        return fetch(`/song_info/${songNumber}`)
+            .then(response => response.json())
+            .then(data => data?.songName || "")
+            .catch(error => {
+                console.error("曲名取得失敗:", error);
+                return "";
+            });
+    }
+
+
+    function getFirstReservedSong(reservedSongs) {
+        if (!Array.isArray(reservedSongs) || reservedSongs.length === 0) {
+            return null;
+        }
+
+        const sortedSongs = [...reservedSongs].sort((a, b) => {
+            const aOrder = Number.isFinite(Number(a?.order)) ? Number(a.order) : Number.MAX_SAFE_INTEGER;
+            const bOrder = Number.isFinite(Number(b?.order)) ? Number(b.order) : Number.MAX_SAFE_INTEGER;
+            if (aOrder !== bOrder) {
+                return aOrder - bOrder;
+            }
+
+            const aCreatedAt = Number.isFinite(Number(a?.created_at)) ? Number(a.created_at) : Number.MAX_SAFE_INTEGER;
+            const bCreatedAt = Number.isFinite(Number(b?.created_at)) ? Number(b.created_at) : Number.MAX_SAFE_INTEGER;
+            return aCreatedAt - bCreatedAt;
+        });
+
+        return sortedSongs[0] || null;
     }
 
     function sendPlaybackEvent(eventType) {
@@ -280,8 +311,9 @@ document.addEventListener("DOMContentLoaded", () => {
         initVariables();
     
         const next = await fetchNextReservedSong();
-        if (next.has_next && next.song && next.song.songNumber) {
-            sessionState.inputNumber = next.song.songNumber;
+        const firstReservedSong = getFirstReservedSong(next.reserved_songs);
+        if (firstReservedSong && firstReservedSong.songNumber) {
+            sessionState.inputNumber = firstReservedSong.songNumber;
             checkSong();
         } else {
             resetToSelection();
@@ -508,7 +540,23 @@ document.addEventListener("DOMContentLoaded", () => {
         inputBox.style.color = "transparent";
         video.src = filename;
         video.style.display = "block";
-        updateTitleBarContent([highlightGreatLeaders(addSpacesIfShort(sessionState.songInfo.songName)), defaultTitleBarMessage]);
+        const nowPlayingTitle = highlightGreatLeaders(addSpacesIfShort(sessionState.songInfo.songName));
+        updateTitleBarContent([nowPlayingTitle, defaultTitleBarMessage]);
+
+        fetchNextReservedSong().then(next => {
+            const firstReservedSong = getFirstReservedSong(next.reserved_songs);
+            if (!firstReservedSong || !firstReservedSong.songNumber) {
+                return;
+            }
+
+            fetchSongNameByNumber(firstReservedSong.songNumber).then(nextSongName => {
+                if (!nextSongName) {
+                    return;
+                }
+                const nextSongTitle = `다음곡: ${highlightGreatLeaders(nextSongName)}`;
+                updateTitleBarContent([nowPlayingTitle, nextSongTitle, defaultTitleBarMessage]);
+            });
+        });
 
         video.play().then(() => {
             sendPlaybackEvent("playStarted"); // Discordのためだけ
@@ -523,8 +571,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 initVariables();
     
                 const next = await fetchNextReservedSong();
-                if (next.has_next && next.song && next.song.songNumber) {
-                    sessionState.inputNumber = next.song.songNumber;
+                const firstReservedSong = getFirstReservedSong(next.reserved_songs);
+                if (firstReservedSong && firstReservedSong.songNumber) {
+                    sessionState.inputNumber = firstReservedSong.songNumber;
                     checkSong();
                 } else {
                     resetToSelection();
@@ -607,4 +656,3 @@ document.addEventListener("DOMContentLoaded", () => {
 
     console.log("《발사준비 끝!》");
 });
-


### PR DESCRIPTION
### Motivation
- Make the reservation flow robust by returning multiple reserved entries from the backend so the client can pick the correct next song and handle non-numeric `order` values safely.
- Ensure the client can deterministically choose the next reservation by `order` then `created_at` and show the upcoming song title in the UI.

### Description
- Change `next_reserved_song` to accumulate multiple reservation documents into `reserved_songs` and return `{"reserved_songs": [...]}` while skipping invalid numeric `order` entries and normalizing timestamps into `created_at` integers.
- Update the frontend `fetchNextReservedSong` to expect `reserved_songs` and change error return to `{ reserved_songs: [] }`.
- Add `getFirstReservedSong` to sort reservations by numeric `order` then `created_at` and return the first candidate, and add `fetchSongNameByNumber` to fetch a song name via `GET /song_info/<songNumber>`.
- Replace previous single-song code paths in `afterTimer`, video end handling, and `playVideo` to use `getFirstReservedSong`, set `sessionState.inputNumber` from that result, and asynchronously fetch and display the next song title in the title bar.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a4feb58883299a13878ac55dab05)