### PR TITLE
Return list of reserved songs and update frontend to sort/select next song

### DIFF
--- a/docker/app.py
+++ b/docker/app.py
@@ -93,6 +93,8 @@ def next_reserved_song():
         "done",
     }
 
+    reserved_songs = []
+
     for doc in documents:
         data = doc.to_dict() or {}
         status = data.get("status")
@@ -135,9 +137,9 @@ def next_reserved_song():
             if timestamp_value is not None:
                 song["created_at"] = timestamp_value
 
-        return jsonify({"has_next": True, "song": song})
+        reserved_songs.append(song)
 
-    return jsonify({"has_next": False})
+    return jsonify({"reserved_songs": reserved_songs})
 
 
 @app.route("/song_info/<songNumber>", methods=["GET"])

--- a/docker/static/js/script.js
+++ b/docker/static/js/script.js
@@ -176,8 +176,55 @@ document.addEventListener("DOMContentLoaded", () => {
             .then(response => response.json())
             .catch(error => {
                 console.error("予約システム問い合わせ失敗:", error);
-                return { has_next: false };
+                return { reserved_songs: [] };
             });
+    }
+
+    function fetchSongNameByNumber(songNumber) {
+        return fetch(`/song_info/${songNumber}`)
+            .then(response => response.json())
+            .then(data => data?.songName || "")
+            .catch(error => {
+                console.error("曲名取得失敗:", error);
+                return "";
+            });
+    }
+
+
+    function getSortedReservedSongs(reservedSongs) {
+        if (!Array.isArray(reservedSongs) || reservedSongs.length === 0) {
+            return [];
+        }
+
+        return [...reservedSongs].sort((a, b) => {
+            const aOrder = Number.isFinite(Number(a?.order)) ? Number(a.order) : Number.MAX_SAFE_INTEGER;
+            const bOrder = Number.isFinite(Number(b?.order)) ? Number(b.order) : Number.MAX_SAFE_INTEGER;
+            if (aOrder !== bOrder) {
+                return aOrder - bOrder;
+            }
+
+            const aCreatedAt = Number.isFinite(Number(a?.created_at)) ? Number(a.created_at) : Number.MAX_SAFE_INTEGER;
+            const bCreatedAt = Number.isFinite(Number(b?.created_at)) ? Number(b.created_at) : Number.MAX_SAFE_INTEGER;
+            return aCreatedAt - bCreatedAt;
+        });
+    }
+
+    function getFirstReservedSong(reservedSongs) {
+        const sortedSongs = getSortedReservedSongs(reservedSongs);
+        return sortedSongs[0] || null;
+    }
+
+    function getNextDisplayReservedSong(reservedSongs, historyDocId) {
+        const sortedSongs = getSortedReservedSongs(reservedSongs);
+        if (sortedSongs.length === 0) {
+            return null;
+        }
+
+        if (historyDocId && sortedSongs[0]?.id === historyDocId) {
+            return sortedSongs[1] || null;
+        }
+
+        return sortedSongs[0];
     }
 
     function sendPlaybackEvent(eventType) {
@@ -280,8 +327,9 @@ document.addEventListener("DOMContentLoaded", () => {
         initVariables();
     
         const next = await fetchNextReservedSong();
-        if (next.has_next && next.song && next.song.songNumber) {
-            sessionState.inputNumber = next.song.songNumber;
+        const firstReservedSong = getFirstReservedSong(next.reserved_songs);
+        if (firstReservedSong && firstReservedSong.songNumber) {
+            sessionState.inputNumber = firstReservedSong.songNumber;
             checkSong();
         } else {
             resetToSelection();
@@ -508,7 +556,23 @@ document.addEventListener("DOMContentLoaded", () => {
         inputBox.style.color = "transparent";
         video.src = filename;
         video.style.display = "block";
-        updateTitleBarContent([highlightGreatLeaders(addSpacesIfShort(sessionState.songInfo.songName)), defaultTitleBarMessage]);
+        const nowPlayingTitle = highlightGreatLeaders(addSpacesIfShort(sessionState.songInfo.songName));
+        updateTitleBarContent([nowPlayingTitle, defaultTitleBarMessage]);
+
+        fetchNextReservedSong().then(next => {
+            const nextDisplaySong = getNextDisplayReservedSong(next.reserved_songs, sessionState.historyDocId);
+            if (!nextDisplaySong || !nextDisplaySong.songNumber) {
+                return;
+            }
+
+            fetchSongNameByNumber(nextDisplaySong.songNumber).then(nextSongName => {
+                if (!nextSongName) {
+                    return;
+                }
+                const nextSongTitle = `다음곡: ${highlightGreatLeaders(nextSongName)}`;
+                updateTitleBarContent([nowPlayingTitle, nextSongTitle, defaultTitleBarMessage]);
+            });
+        });
 
         video.play().then(() => {
             sendPlaybackEvent("playStarted"); // Discordのためだけ
@@ -523,8 +587,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 initVariables();
     
                 const next = await fetchNextReservedSong();
-                if (next.has_next && next.song && next.song.songNumber) {
-                    sessionState.inputNumber = next.song.songNumber;
+                const firstReservedSong = getFirstReservedSong(next.reserved_songs);
+                if (firstReservedSong && firstReservedSong.songNumber) {
+                    sessionState.inputNumber = firstReservedSong.songNumber;
                     checkSong();
                 } else {
                     resetToSelection();
@@ -607,4 +672,3 @@ document.addEventListener("DOMContentLoaded", () => {
 
     console.log("《발사준비 끝!》");
 });
-


### PR DESCRIPTION
### Motivation
- Change the `/next_reserved_song` API to return a list of reservation entries so the frontend can decide ordering and which entry to display next. 
- Make frontend logic robust to mixed/invalid `order` and `created_at` values and enable showing the upcoming song title in the title bar.

### Description
- Modified the server handler for `GET /next_reserved_song` to collect all valid reservation documents into `reserved_songs` and return `{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a4feb58883299a13878ac55dab05)