### PR TITLE
次曲表示ロジックをhistoryDocId比較からsongNumber比較へ変更

### DIFF
--- a/docker/static/js/script.js
+++ b/docker/static/js/script.js
@@ -214,13 +214,13 @@ document.addEventListener("DOMContentLoaded", () => {
         return sortedSongs[0] || null;
     }
 
-    function getNextDisplayReservedSong(reservedSongs, historyDocId) {
+    function getNextDisplayReservedSong(reservedSongs, songNumber) {
         const sortedSongs = getSortedReservedSongs(reservedSongs);
         if (sortedSongs.length === 0) {
             return null;
         }
 
-        if (historyDocId && sortedSongs[0]?.id === historyDocId) {
+        if (songNumber && sortedSongs[0]?.songNumber === songNumber) {
             return sortedSongs[1] || null;
         }
 
@@ -560,7 +560,7 @@ document.addEventListener("DOMContentLoaded", () => {
         updateTitleBarContent([nowPlayingTitle, defaultTitleBarMessage]);
 
         fetchNextReservedSong().then(next => {
-            const nextDisplaySong = getNextDisplayReservedSong(next.reserved_songs, sessionState.historyDocId);
+            const nextDisplaySong = getNextDisplayReservedSong(next.reserved_songs, sessionState.inputNumber);
             if (!nextDisplaySong || !nextDisplaySong.songNumber) {
                 return;
             }


### PR DESCRIPTION
### Motivation
- 先頭予約曲と現在入力中の曲を比較して次曲表示を切替える際に、履歴ドキュメントIDではなく曲番号で判定するための修正。

### Description
- `getNextDisplayReservedSong` の第2引数名を `historyDocId` から `songNumber` に変更し、比較を `sortedSongs[0]?.songNumber === songNumber` に置き換えました。 (ファイル: `docker/static/js/script.js`)。
- `fetchNextReservedSong()` を受け取る側の呼び出しを更新し、`sessionState.historyDocId` ではなく `sessionState.inputNumber` を引数として渡すようにしました。 (呼び出し箇所: `playVideo`)。

### Testing
- `node --check docker/static/js/script.js` を実行して構文チェックを行い、エラーは発生しませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a22913a67083299f335a29f90c1740)